### PR TITLE
Fix OpenRouter pricing map coming back empty (per-token string values)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Node helpers: fix OpenRouter string pricing parsing while preserving numeric catalog compatibility (thanks @devYRPauli)
+
 ## 0.1.1 (2025-12-23)
 
 - Tooling: bump pnpm to 10.26.1

--- a/src/node/openrouter.ts
+++ b/src/node/openrouter.ts
@@ -1,4 +1,4 @@
-import { pricingFromUsdPerMillion } from "../pricing.js";
+import { pricingFromUsdPerToken } from "../pricing.js";
 import type { PricingMap } from "../types.js";
 import type { FetchFn } from "./types.js";
 
@@ -9,8 +9,9 @@ export type OpenRouterModelInfo = {
   id: string;
   context_length?: number;
   pricing?: {
-    prompt?: number;
-    completion?: number;
+    // OpenRouter returns these as USD-per-token numeric strings (e.g. "0.000005").
+    prompt?: string | number;
+    completion?: string | number;
   };
 };
 
@@ -20,7 +21,7 @@ const DEFAULT_TTL_MS = 5 * 60 * 1000;
 /**
  * Fetches the OpenRouter model catalog (cached in-memory per `apiKey`).
  *
- * Note: OpenRouter pricing values are USD per 1M tokens.
+ * Note: OpenRouter pricing values are USD per token, returned as numeric strings.
  */
 export async function fetchOpenRouterModelCatalog({
   apiKey,
@@ -48,27 +49,35 @@ export async function fetchOpenRouterModelCatalog({
 }
 
 /**
+ * Parses an OpenRouter price field into a finite, non-negative USD-per-token number.
+ *
+ * OpenRouter publishes prices as numeric strings (e.g. "0.000005"); numbers are
+ * accepted too for robustness. Returns `null` for missing/malformed values.
+ */
+function parseUsdPerToken(value: string | number | undefined): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  }
+  return null;
+}
+
+/**
  * Converts OpenRouter's catalog pricing to a `PricingMap`.
  *
- * Entries without pricing are skipped.
+ * OpenRouter prices are already USD per token, so they map straight through.
+ * Entries without valid pricing are skipped.
  */
 export function openRouterPricingMapFromCatalog(catalog: OpenRouterModelInfo[]): PricingMap {
   const map: PricingMap = {};
   for (const entry of catalog) {
-    const prompt = entry.pricing?.prompt;
-    const completion = entry.pricing?.completion;
-    if (
-      typeof prompt === "number" &&
-      Number.isFinite(prompt) &&
-      prompt >= 0 &&
-      typeof completion === "number" &&
-      Number.isFinite(completion) &&
-      completion >= 0
-    ) {
-      map[entry.id] = pricingFromUsdPerMillion({
-        inputUsdPerMillion: prompt,
-        outputUsdPerMillion: completion,
-      });
+    const inputUsdPerToken = parseUsdPerToken(entry.pricing?.prompt);
+    const outputUsdPerToken = parseUsdPerToken(entry.pricing?.completion);
+    if (inputUsdPerToken !== null && outputUsdPerToken !== null) {
+      map[entry.id] = pricingFromUsdPerToken({ inputUsdPerToken, outputUsdPerToken });
     }
   }
   return map;

--- a/src/node/openrouter.ts
+++ b/src/node/openrouter.ts
@@ -1,4 +1,4 @@
-import { pricingFromUsdPerToken } from "../pricing.js";
+import { pricingFromUsdPerMillion, pricingFromUsdPerToken } from "../pricing.js";
 import type { PricingMap } from "../types.js";
 import type { FetchFn } from "./types.js";
 
@@ -49,18 +49,22 @@ export async function fetchOpenRouterModelCatalog({
 }
 
 /**
- * Parses an OpenRouter price field into a finite, non-negative USD-per-token number.
+ * Parses an OpenRouter price field into a finite, non-negative number.
  *
- * OpenRouter publishes prices as numeric strings (e.g. "0.000005"); numbers are
- * accepted too for robustness. Returns `null` for missing/malformed values.
+ * OpenRouter publishes prices as numeric strings in USD per token (e.g. "0.000005").
+ * Numeric catalog inputs predate that live shape and are preserved as USD per 1M.
+ * Returns `null` for missing/malformed values.
  */
-function parseUsdPerToken(value: string | number | undefined): number | null {
+function parseOpenRouterPrice(value: string | number | undefined): {
+  value: number;
+  unit: "per-token" | "per-million";
+} | null {
   if (typeof value === "number") {
-    return Number.isFinite(value) && value >= 0 ? value : null;
+    return Number.isFinite(value) && value >= 0 ? { value, unit: "per-million" } : null;
   }
   if (typeof value === "string" && value.trim() !== "") {
     const parsed = Number(value);
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+    return Number.isFinite(parsed) && parsed >= 0 ? { value: parsed, unit: "per-token" } : null;
   }
   return null;
 }
@@ -74,10 +78,23 @@ function parseUsdPerToken(value: string | number | undefined): number | null {
 export function openRouterPricingMapFromCatalog(catalog: OpenRouterModelInfo[]): PricingMap {
   const map: PricingMap = {};
   for (const entry of catalog) {
-    const inputUsdPerToken = parseUsdPerToken(entry.pricing?.prompt);
-    const outputUsdPerToken = parseUsdPerToken(entry.pricing?.completion);
-    if (inputUsdPerToken !== null && outputUsdPerToken !== null) {
-      map[entry.id] = pricingFromUsdPerToken({ inputUsdPerToken, outputUsdPerToken });
+    const inputPrice = parseOpenRouterPrice(entry.pricing?.prompt);
+    const outputPrice = parseOpenRouterPrice(entry.pricing?.completion);
+    if (inputPrice !== null && outputPrice !== null) {
+      map[entry.id] =
+        inputPrice.unit === "per-token" && outputPrice.unit === "per-token"
+          ? pricingFromUsdPerToken({
+              inputUsdPerToken: inputPrice.value,
+              outputUsdPerToken: outputPrice.value,
+            })
+          : pricingFromUsdPerMillion({
+              inputUsdPerMillion:
+                inputPrice.unit === "per-million" ? inputPrice.value : inputPrice.value * 1_000_000,
+              outputUsdPerMillion:
+                outputPrice.unit === "per-million"
+                  ? outputPrice.value
+                  : outputPrice.value * 1_000_000,
+            });
     }
   }
   return map;

--- a/tests/node-openrouter.test.ts
+++ b/tests/node-openrouter.test.ts
@@ -37,13 +37,22 @@ describe("tokentally/node openrouter", () => {
     expect(map["openai/gpt-4o-mini"]?.outputUsdPerToken).toBe(0.0000006);
   });
 
-  it("also accepts numeric per-token pricing", () => {
+  it("preserves numeric pricing as USD per million", () => {
     const map = openRouterPricingMapFromCatalog([
-      { id: "xai/grok-4", pricing: { prompt: 0.000003, completion: 0.000015 } },
+      { id: "xai/grok-4", pricing: { prompt: 3, completion: 15 } },
     ]);
 
     expect(map["xai/grok-4"]?.inputUsdPerToken).toBe(0.000003);
     expect(map["xai/grok-4"]?.outputUsdPerToken).toBe(0.000015);
+  });
+
+  it("accepts mixed string and numeric pricing without changing numeric units", () => {
+    const map = openRouterPricingMapFromCatalog([
+      { id: "mixed/model", pricing: { prompt: "0.000004", completion: 12 } },
+    ]);
+
+    expect(map["mixed/model"]?.inputUsdPerToken).toBe(0.000004);
+    expect(map["mixed/model"]?.outputUsdPerToken).toBe(0.000012);
   });
 
   it("keeps free models priced at zero", () => {

--- a/tests/node-openrouter.test.ts
+++ b/tests/node-openrouter.test.ts
@@ -1,13 +1,24 @@
-import { fetchOpenRouterPricingMap } from "../src/node/openrouter.js";
+import {
+  fetchOpenRouterPricingMap,
+  openRouterPricingMapFromCatalog,
+} from "../src/node/openrouter.js";
 
 describe("tokentally/node openrouter", () => {
-  it("fetches and converts pricing map", async () => {
+  it("parses OpenRouter's USD-per-token string pricing", async () => {
+    // OpenRouter's /api/v1/models returns pricing as USD-per-token *strings*,
+    // e.g. "0.000005" for a model that costs $5 / 1M input tokens.
     const fetchImpl = async () =>
       new Response(
         JSON.stringify({
           data: [
-            { id: "openai/gpt-5.2", pricing: { prompt: 2, completion: 10 } },
-            { id: "xai/grok-4", pricing: { prompt: 3, completion: 15 } },
+            {
+              id: "anthropic/claude-opus-4.8",
+              pricing: { prompt: "0.000005", completion: "0.000025" },
+            },
+            {
+              id: "openai/gpt-4o-mini",
+              pricing: { prompt: "0.00000015", completion: "0.0000006" },
+            },
           ],
         }),
         { status: 200 },
@@ -18,7 +29,39 @@ describe("tokentally/node openrouter", () => {
       fetchImpl,
       ttlMs: 1_000_000,
     });
-    expect(map["openai/gpt-5.2"]?.inputUsdPerToken).toBeCloseTo(2 / 1_000_000);
-    expect(map["openai/gpt-5.2"]?.outputUsdPerToken).toBeCloseTo(10 / 1_000_000);
+
+    // Values are already per-token, so they pass through unchanged.
+    expect(map["anthropic/claude-opus-4.8"]?.inputUsdPerToken).toBe(0.000005);
+    expect(map["anthropic/claude-opus-4.8"]?.outputUsdPerToken).toBe(0.000025);
+    expect(map["openai/gpt-4o-mini"]?.inputUsdPerToken).toBe(0.00000015);
+    expect(map["openai/gpt-4o-mini"]?.outputUsdPerToken).toBe(0.0000006);
+  });
+
+  it("also accepts numeric per-token pricing", () => {
+    const map = openRouterPricingMapFromCatalog([
+      { id: "xai/grok-4", pricing: { prompt: 0.000003, completion: 0.000015 } },
+    ]);
+
+    expect(map["xai/grok-4"]?.inputUsdPerToken).toBe(0.000003);
+    expect(map["xai/grok-4"]?.outputUsdPerToken).toBe(0.000015);
+  });
+
+  it("keeps free models priced at zero", () => {
+    const map = openRouterPricingMapFromCatalog([
+      { id: "free/model", pricing: { prompt: "0", completion: "0" } },
+    ]);
+
+    expect(map["free/model"]?.inputUsdPerToken).toBe(0);
+    expect(map["free/model"]?.outputUsdPerToken).toBe(0);
+  });
+
+  it("skips entries with malformed or missing pricing", () => {
+    const map = openRouterPricingMapFromCatalog([
+      { id: "broken/model", pricing: { prompt: "abc", completion: "1" } },
+      { id: "missing/model" },
+    ]);
+
+    expect(map["broken/model"]).toBeUndefined();
+    expect(map["missing/model"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
**Problem.** `fetchOpenRouterPricingMap` / `openRouterPricingMapFromCatalog` return an empty map for real OpenRouter data.

OpenRouter's `/api/v1/models` returns each price as a USD-**per-token** numeric **string**, e.g. for `anthropic/claude-opus-4.8`:

```json
"pricing": { "prompt": "0.000005", "completion": "0.000025" }
```

(`0.000005 × 1e6 = $5 / 1M tokens`, the correct price.)

The current code only accepts `typeof === "number"`, so every entry fails the guard and is skipped — the map is always empty. Separately, it runs values through `pricingFromUsdPerMillion` (÷1e6), which would make an already-per-token value 1,000,000× too low if a number ever reached it.

**Fix.** Parse `prompt`/`completion` as USD-per-token (string or number) and map them straight through with `pricingFromUsdPerToken`. This matches the LiteLLM path (`input_cost_per_token` used directly) and the README, which lists OpenRouter as a per-token pricing source. Free models (`"0"`) stay at `$0`; malformed entries are skipped.

**Note on the numeric path.** `openRouterPricingMapFromCatalog` is exported. Previously *numeric* `prompt`/`completion` inputs were read as USD-per-million (per the old test); they're now USD-per-token, consistent with the string path and OpenRouter's actual format. The live API only ever returns strings, so this affects only hand-built numeric catalogs. I chose per-token for one consistent unit rather than mixing units by JS type — happy to preserve the numeric per-million path instead if you'd prefer.

**Real-behavior proof.** Calling `fetchOpenRouterPricingMap` against the live `openrouter.ai/api/v1/models` endpoint:

Before (`main`):
```
priced_models: 0
anthropic/claude-opus-4.8: null
openai/gpt-4o-mini: null
```

After (this PR):
```
priced_models: 340
anthropic/claude-opus-4.8: {"inputUsdPerToken":0.000005,"outputUsdPerToken":0.000025}
openai/gpt-4o-mini: {"inputUsdPerToken":1.5e-7,"outputUsdPerToken":6e-7}
```

The helper goes from an empty map to pricing every model, with values matching OpenRouter's published rates ($5 / $25 per 1M for opus-4.8; $0.15 / $0.60 per 1M for gpt-4o-mini).

**Verification.** New tests fail on `main` (string ⇒ empty map; number ⇒ 1e6× off) and pass after the change. `pnpm check` (format, lint, type-aware lint, typecheck, coverage) is green.

Note: the previous test fed numeric inputs and asserted a per-million conversion — neither matches the live API — so it's replaced with string/number per-token cases plus free/malformed coverage.

Used the Claude CLI while working on this.
