### PR TITLE
fix: normalize nested usage details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Core API: normalize nested provider usage details such as cached input tokens and reasoning tokens
 - Node helpers: fix OpenRouter string pricing parsing while preserving numeric catalog compatibility (thanks @devYRPauli)
 
 ## 0.1.1 (2025-12-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Core API: normalize nested provider usage details such as cached input tokens and reasoning tokens
+- Core API: normalize nested provider usage details such as cached input tokens and reasoning tokens (thanks @kiranmagic7)
 - Node helpers: fix OpenRouter string pricing parsing while preserving numeric catalog compatibility (thanks @devYRPauli)
 
 ## 0.1.1 (2025-12-23)

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ const pricing = resolvePricingFromMap(map, "openai/gpt-5.2");
 
 ## API
 
-- `normalizeTokenUsage(raw)` → `{ inputTokens, outputTokens, reasoningTokens, totalTokens } | null`
+- `normalizeTokenUsage(raw)` → `{ inputTokens, outputTokens, cachedInputTokens, reasoningTokens, totalTokens } | null`
 - `pricingFromUsdPerMillion({ inputUsdPerMillion, outputUsdPerMillion })`
 - `estimateUsdCost({ usage, pricing })`
 - `tallyCosts(calls)` → totals + per-model breakdown

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const pricing = resolvePricingFromMap(map, "openai/gpt-5.2");
 - `normalizeTokenUsage(raw)` → `{ inputTokens, outputTokens, cachedInputTokens, reasoningTokens, totalTokens } | null`
 - `pricingFromUsdPerMillion({ inputUsdPerMillion, outputUsdPerMillion })`
 - `estimateUsdCost({ usage, pricing })`
-- `tallyCosts(calls)` → totals + per-model breakdown
+- `tallyCosts({ calls, resolvePricing })` → totals + per-model breakdown
 
 ## Non-goals
 

--- a/src/tally.ts
+++ b/src/tally.ts
@@ -39,9 +39,15 @@ export type TallyResult = {
 };
 
 function addUsage(a: TokenUsageNormalized, b: TokenUsageNormalized): TokenUsageNormalized {
+  const cachedInputTokens =
+    a.cachedInputTokens != null || b.cachedInputTokens != null
+      ? (a.cachedInputTokens ?? 0) + (b.cachedInputTokens ?? 0)
+      : undefined;
+
   return {
     inputTokens: a.inputTokens + b.inputTokens,
     outputTokens: a.outputTokens + b.outputTokens,
+    ...(cachedInputTokens != null ? { cachedInputTokens } : {}),
     reasoningTokens: (a.reasoningTokens ?? 0) + (b.reasoningTokens ?? 0),
     totalTokens: (a.totalTokens ?? 0) + (b.totalTokens ?? 0),
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@
 export type TokenUsageNormalized = {
   inputTokens: number;
   outputTokens: number;
+  cachedInputTokens?: number;
   reasoningTokens?: number;
   totalTokens?: number;
 };

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -12,6 +12,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function fieldFromRecord(value: unknown, field: string): unknown {
+  return isRecord(value) ? value[field] : undefined;
+}
+
+function firstTokenCount(values: unknown[]): number | null {
+  return values.map(toFiniteNonNegativeInt).find((v) => v != null) ?? null;
+}
+
 /**
  * Best-effort normalization of token usage across common provider payloads.
  *
@@ -19,11 +27,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  * - `prompt_tokens`, `completion_tokens`
  * - `input_tokens`, `output_tokens`
  * - `inputTokens`, `outputTokens`, `reasoningTokens`
+ * - nested details such as `completion_tokens_details.reasoning_tokens`
+ *   and `prompt_tokens_details.cached_tokens`
  *
  * Returns `null` if no recognized token fields are found.
  */
 export function normalizeTokenUsage(raw: unknown): TokenUsageNormalized | null {
   if (!isRecord(raw)) return null;
+
+  const inputDetails = raw.input_tokens_details ?? raw.prompt_tokens_details;
+  const outputDetails = raw.output_tokens_details ?? raw.completion_tokens_details;
 
   const inputCandidates = [
     raw.inputTokens,
@@ -38,16 +51,29 @@ export function normalizeTokenUsage(raw: unknown): TokenUsageNormalized | null {
     raw.output_tokens,
     raw.completion_tokens,
   ];
+  const cachedInputCandidates = [
+    raw.cachedInputTokens,
+    raw.cached_input_tokens,
+    fieldFromRecord(inputDetails, "cached_tokens"),
+    fieldFromRecord(inputDetails, "cache_read_input_tokens"),
+  ];
   const reasoningCandidates = [raw.reasoningTokens, raw.reasoning_tokens];
+  const nestedReasoningCandidates = [fieldFromRecord(outputDetails, "reasoning_tokens")];
   const totalCandidates = [raw.totalTokens, raw.total_tokens];
 
-  const inputTokens = inputCandidates.map(toFiniteNonNegativeInt).find((v) => v != null) ?? null;
-  const outputTokens = outputCandidates.map(toFiniteNonNegativeInt).find((v) => v != null) ?? null;
-  const reasoningTokens =
-    reasoningCandidates.map(toFiniteNonNegativeInt).find((v) => v != null) ?? null;
-  const totalTokens = totalCandidates.map(toFiniteNonNegativeInt).find((v) => v != null) ?? null;
+  const inputTokens = firstTokenCount(inputCandidates);
+  const outputTokens = firstTokenCount(outputCandidates);
+  const cachedInputTokens = firstTokenCount(cachedInputCandidates);
+  const reasoningTokens = firstTokenCount([...reasoningCandidates, ...nestedReasoningCandidates]);
+  const totalTokens = firstTokenCount(totalCandidates);
 
-  if (inputTokens == null && outputTokens == null && reasoningTokens == null && totalTokens == null)
+  if (
+    inputTokens == null &&
+    outputTokens == null &&
+    cachedInputTokens == null &&
+    reasoningTokens == null &&
+    totalTokens == null
+  )
     return null;
 
   const normalizedInput = inputTokens ?? 0;
@@ -58,6 +84,7 @@ export function normalizeTokenUsage(raw: unknown): TokenUsageNormalized | null {
   return {
     inputTokens: normalizedInput,
     outputTokens: normalizedOutput,
+    ...(cachedInputTokens != null ? { cachedInputTokens } : {}),
     ...(reasoningTokens != null ? { reasoningTokens: normalizedReasoning } : {}),
     ...(totalTokens != null ? { totalTokens } : { totalTokens: inferredTotal }),
   };

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -64,7 +64,9 @@ export function normalizeTokenUsage(raw: unknown): TokenUsageNormalized | null {
   const inputTokens = firstTokenCount(inputCandidates);
   const outputTokens = firstTokenCount(outputCandidates);
   const cachedInputTokens = firstTokenCount(cachedInputCandidates);
-  const reasoningTokens = firstTokenCount([...reasoningCandidates, ...nestedReasoningCandidates]);
+  const topLevelReasoningTokens = firstTokenCount(reasoningCandidates);
+  const nestedReasoningTokens = firstTokenCount(nestedReasoningCandidates);
+  const reasoningTokens = topLevelReasoningTokens ?? nestedReasoningTokens;
   const totalTokens = firstTokenCount(totalCandidates);
 
   if (
@@ -79,7 +81,10 @@ export function normalizeTokenUsage(raw: unknown): TokenUsageNormalized | null {
   const normalizedInput = inputTokens ?? 0;
   const normalizedOutput = outputTokens ?? 0;
   const normalizedReasoning = reasoningTokens ?? 0;
-  const inferredTotal = normalizedInput + normalizedOutput + normalizedReasoning;
+  const inferredTotal =
+    normalizedInput +
+    normalizedOutput +
+    (topLevelReasoningTokens != null ? normalizedReasoning : 0);
 
   return {
     inputTokens: normalizedInput,

--- a/tests/tally.test.ts
+++ b/tests/tally.test.ts
@@ -91,7 +91,7 @@ describe("tallyCosts", () => {
       outputTokens: 35,
       cachedInputTokens: 62,
       reasoningTokens: 11,
-      totalTokens: 186,
+      totalTokens: 175,
     });
   });
 });

--- a/tests/tally.test.ts
+++ b/tests/tally.test.ts
@@ -59,4 +59,39 @@ describe("tallyCosts", () => {
       (expectedOpenAi?.totalUsd ?? 0) + (expectedXai?.totalUsd ?? 0),
     );
   });
+
+  it("aggregates cached input and reasoning token details", async () => {
+    const result = await tallyCosts({
+      calls: [
+        {
+          model: "openai/gpt-5.2",
+          usage: normalizeTokenUsage({
+            prompt_tokens: 100,
+            completion_tokens: 25,
+            prompt_tokens_details: { cached_tokens: 50 },
+            completion_tokens_details: { reasoning_tokens: 8 },
+          }),
+        },
+        {
+          model: "openai/gpt-5.2",
+          usage: normalizeTokenUsage({
+            prompt_tokens: 40,
+            completion_tokens: 10,
+            prompt_tokens_details: { cached_tokens: 12 },
+            completion_tokens_details: { reasoning_tokens: 3 },
+          }),
+        },
+      ],
+      resolvePricing: () =>
+        pricingFromUsdPerMillion({ inputUsdPerMillion: 1, outputUsdPerMillion: 2 }),
+    });
+
+    expect(result.byModel["openai/gpt-5.2"]?.usage).toEqual({
+      inputTokens: 140,
+      outputTokens: 35,
+      cachedInputTokens: 62,
+      reasoningTokens: 11,
+      totalTokens: 186,
+    });
+  });
 });

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -25,6 +25,51 @@ describe("normalizeTokenUsage", () => {
     ).toEqual({ inputTokens: 100, outputTokens: 20, reasoningTokens: 5, totalTokens: 125 });
   });
 
+  it("normalizes nested OpenAI usage details", () => {
+    expect(
+      normalizeTokenUsage({
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        total_tokens: 120,
+        prompt_tokens_details: { cached_tokens: 40 },
+        completion_tokens_details: { reasoning_tokens: 7 },
+      }),
+    ).toEqual({
+      inputTokens: 100,
+      outputTokens: 20,
+      cachedInputTokens: 40,
+      reasoningTokens: 7,
+      totalTokens: 120,
+    });
+  });
+
+  it("normalizes nested Responses API usage details", () => {
+    expect(
+      normalizeTokenUsage({
+        input_tokens: 150,
+        output_tokens: 30,
+        total_tokens: 180,
+        input_tokens_details: { cached_tokens: 25 },
+        output_tokens_details: { reasoning_tokens: 12 },
+      }),
+    ).toEqual({
+      inputTokens: 150,
+      outputTokens: 30,
+      cachedInputTokens: 25,
+      reasoningTokens: 12,
+      totalTokens: 180,
+    });
+  });
+
+  it("accepts top-level cached input token aliases", () => {
+    expect(normalizeTokenUsage({ inputTokens: 10, cached_input_tokens: 4 })).toEqual({
+      inputTokens: 10,
+      outputTokens: 0,
+      cachedInputTokens: 4,
+      totalTokens: 10,
+    });
+  });
+
   it("fills missing totals", () => {
     expect(normalizeTokenUsage({ prompt_tokens: 7, completion_tokens: 2 })).toEqual({
       inputTokens: 7,

--- a/tests/usage.test.ts
+++ b/tests/usage.test.ts
@@ -70,6 +70,21 @@ describe("normalizeTokenUsage", () => {
     });
   });
 
+  it("does not double-count nested reasoning when inferring totals", () => {
+    expect(
+      normalizeTokenUsage({
+        prompt_tokens: 100,
+        completion_tokens: 25,
+        completion_tokens_details: { reasoning_tokens: 8 },
+      }),
+    ).toEqual({
+      inputTokens: 100,
+      outputTokens: 25,
+      reasoningTokens: 8,
+      totalTokens: 125,
+    });
+  });
+
   it("fills missing totals", () => {
     expect(normalizeTokenUsage({ prompt_tokens: 7, completion_tokens: 2 })).toEqual({
       inputTokens: 7,


### PR DESCRIPTION
## Summary

- Normalize nested provider usage details for cached input tokens and reasoning tokens.
- Preserve `cachedInputTokens` through `tallyCosts()` aggregation when providers expose it.
- Add regression coverage for Chat Completions-style and Responses API-style usage payloads.

## Validation

- `pnpm test` — 5 files / 21 tests passed
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm check` — passed with coverage
- `git diff --check` — passed

## Notes

This keeps existing pricing behavior unchanged. `cachedInputTokens` is exposed as normalized usage metadata; discounted cached-input billing can stay a separate pricing feature if/when the library adds provider-specific cached-token pricing.
