### PR TITLE
chore: remove stale Biome ignore file

### DIFF
--- a/.biomeignore
+++ b/.biomeignore
@@ -1,3 +1,0 @@
-coverage/**
-dist/**
-node_modules/**


### PR DESCRIPTION
## Summary

- remove the obsolete `.biomeignore` left behind by the Oxfmt/Oxlint migration
- leave `.gitignore` unchanged because all three generated paths are already ignored there

## Cleanup evidence

- `.biomeignore` — introduced by `fb5cb3b` (`feat: add tokentally`) together with `biome.json` and the `@biomejs/biome` dependency. Commit `1ff2f26` (`build: adopt oxlint oxfmt and tsgo`) later removed Biome itself but missed this companion ignore file. The repository has no remaining Biome dependency, command, config, or reference to this filename; its `coverage/**`, `dist/**`, and `node_modules/**` entries duplicate active ignores.

## Verification

- `CI=true pnpm install --frozen-lockfile`
- `CI=true pnpm check` (5 test files, 25 tests)
- structured Codex autoreview: clean, no accepted/actionable findings
