### PR TITLE
feat: add opt-in strict cached-input accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ const usage = normalizeTokenUsage({
   output_tokens: 30,
   cache_read_input_tokens: 80,
 });
-// { inputTokens: 120, outputTokens: 30, cachedInputTokens: 80, totalTokens: 230 }
+// { inputTokens: 120, outputTokens: 30, uncachedInputTokens: 120,
+//   cachedInputTokens: 80, totalTokens: 230 }
 ```
 
 ## Price and tally calls
@@ -77,6 +78,74 @@ as free. `CostBreakdown.inputUsd` includes all three input categories.
 `tallyCosts()` accepts a synchronous or asynchronous pricing resolver. Calls without usage still
 count in the per-model breakdown; models without pricing retain their usage but have a `null`
 cost and do not contribute to the total.
+
+### Cache ambiguity and strict validation
+
+When constructing usage manually, supply `uncachedInputTokens` whenever either
+`cachedInputTokens` or `cacheCreationInputTokens` is present, including a zero cache count.
+The uncached count excludes both cache reads and cache creation. OpenAI's prompt count includes
+cache reads; Anthropic's input count excludes cache reads and writes. A flattened object alone
+cannot tell the estimator which interpretation you intended.
+
+For example, with input at $1, output at $2, and cache reads at $0.10 per million tokens:
+
+| Usage interpretation     | Input | Cached | Uncached | Total for 50 output tokens |
+| ------------------------ | ----- | ------ | -------- | -------------------------- |
+| OpenAI inclusive input   | 1,000 | 400    | 600      | $0.00074                   |
+| Anthropic additive input | 1,000 | 400    | 1,000    | $0.00114                   |
+
+The default still treats `inputTokens` as uncached when `uncachedInputTokens` is missing. The
+ambiguous manual object `{ inputTokens: 1000, outputTokens: 50, cachedInputTokens: 400 }`
+therefore retains its $0.00114 estimate. The result now includes a single structured warning:
+`warnings: [{ code: "AMBIGUOUS_CACHED_INPUT", message: "..." }]`. Inspect `cost?.warnings` from
+`estimateUsdCost()` or `result.warnings` from `tallyCosts()`. Warnings are omitted for unambiguous
+usage and deduplicated to one entry per result, even when a tally contains many ambiguous calls.
+They are returned on each affected invocation, never written to the console or stderr.
+
+Opt into rejection with `requireExplicitUncachedInputTokens: true` on either function:
+
+```js
+import {
+  estimateUsdCost,
+  normalizeTokenUsage,
+  pricingFromUsdPerMillion,
+  tallyCosts,
+} from "tokentally";
+
+const pricing = pricingFromUsdPerMillion({
+  inputUsdPerMillion: 1,
+  outputUsdPerMillion: 2,
+  cachedInputUsdPerMillion: 0.1,
+});
+const usage = normalizeTokenUsage({
+  prompt_tokens: 1000,
+  completion_tokens: 50,
+  prompt_tokens_details: { cached_tokens: 400 },
+});
+const cost = estimateUsdCost({ usage, pricing, requireExplicitUncachedInputTokens: true });
+// cost.totalUsd is 0.00074; no warnings.
+const result = await tallyCosts({
+  calls: [{ model: "example/model", usage }],
+  resolvePricing: () => pricing,
+  requireExplicitUncachedInputTokens: true,
+});
+// result.total.totalUsd is 0.00074; no warnings.
+```
+
+Strict estimation throws a `TypeError` for ambiguous input; strict tallying rejects its promise.
+The error explains how to normalize the original provider payload or pass an explicit uncached
+count. Validation checks every original call before aggregation and pricing resolution, so mixing
+normalized and ambiguous manual calls cannot hide the ambiguity. It also applies when pricing is
+missing. Default estimation with missing usage or pricing still returns `null`; a default tally
+can return warnings even when its total is `null` because no pricing was found.
+
+Normalize the **original provider payload**, not an already flattened ambiguous object: lost
+provider semantics cannot be recovered. For manual OpenAI usage in the table above, passing
+`uncachedInputTokens: 600` is sufficient; manual Anthropic usage needs `uncachedInputTokens: 1000`.
+
+Ambiguous manual usage is deprecated. Strict validation is planned to become the default in a
+future compatibility-changing release; its major/minor version and migration timing remain
+undecided. This release keeps strict validation opt-in and preserves existing numeric totals.
 
 ## Load catalog pricing in Node.js
 

--- a/src/tally.ts
+++ b/src/tally.ts
@@ -1,18 +1,56 @@
-import type { CostBreakdown, Pricing, PricingResolver, TokenUsageNormalized } from "./types.js";
+import type {
+  CostBreakdown,
+  CostEstimate,
+  CostEstimationOptions,
+  Pricing,
+  PricingResolver,
+  TokenUsageNormalized,
+  TokenUsageWarning,
+} from "./types.js";
+
+function checkCacheUsage(
+  usage: TokenUsageNormalized,
+  requireExplicitUncachedInputTokens: boolean,
+): TokenUsageWarning | undefined {
+  if (
+    usage.uncachedInputTokens != null ||
+    (usage.cachedInputTokens == null && usage.cacheCreationInputTokens == null)
+  ) {
+    return undefined;
+  }
+  const message =
+    "Cache-bearing usage is ambiguous without uncachedInputTokens. " +
+    "Normalize the original provider payload with normalizeTokenUsage() or pass an explicit " +
+    "uncachedInputTokens count excluding cache reads and cache creation.";
+  if (requireExplicitUncachedInputTokens) throw new TypeError(message);
+  return { code: "AMBIGUOUS_CACHED_INPUT", message };
+}
 
 /**
  * Estimates USD cost for a single call from normalized usage + pricing.
  *
  * Returns `null` if either `usage` or `pricing` is missing.
+ * Strict validation checks present usage even when pricing is missing.
+ * Otherwise, ambiguous usage adds one structured warning to the result; no logging occurs.
  */
 export function estimateUsdCost({
   usage,
   pricing,
+  requireExplicitUncachedInputTokens = false,
 }: {
   usage: TokenUsageNormalized | null;
   pricing: Pricing | null;
-}): CostBreakdown | null {
-  if (!usage || !pricing) return null;
+} & CostEstimationOptions): CostEstimate | null {
+  if (!usage) return null;
+  const warning = checkCacheUsage(usage, requireExplicitUncachedInputTokens);
+  if (!pricing) return null;
+  return {
+    ...calculateUsdCost(usage, pricing),
+    ...(warning ? { warnings: [warning] } : {}),
+  };
+}
+
+function calculateUsdCost(usage: TokenUsageNormalized, pricing: Pricing): CostBreakdown {
   const uncachedInputTokens = usage.uncachedInputTokens ?? usage.inputTokens;
   const cachedInputTokens = usage.cachedInputTokens ?? 0;
   const cacheCreationInputTokens = usage.cacheCreationInputTokens ?? 0;
@@ -43,6 +81,8 @@ export type TallyCall = {
  */
 export type TallyResult = {
   total: CostBreakdown | null;
+  /** One warning if any original call had ambiguous cache usage, even without pricing. */
+  warnings?: TokenUsageWarning[];
   byModel: Record<
     string,
     { calls: number; usage: TokenUsageNormalized; cost: CostBreakdown | null }
@@ -82,19 +122,27 @@ function emptyUsage(): TokenUsageNormalized {
  * Tallies costs across a list of calls, grouped by `model`.
  *
  * `resolvePricing(modelId)` can be async (e.g. catalog fetch).
+ * Validates each call before aggregation; warnings are deduplicated across the entire result.
  */
 export async function tallyCosts({
   calls,
   resolvePricing,
+  requireExplicitUncachedInputTokens = false,
 }: {
   calls: TallyCall[];
   resolvePricing: PricingResolver;
-}): Promise<TallyResult> {
+} & CostEstimationOptions): Promise<TallyResult> {
   const byModel: TallyResult["byModel"] = {};
+  let warning: TokenUsageWarning | undefined;
 
   for (const call of calls) {
     const model = call.model;
     const usage = call.usage;
+    // Aggregation can fill the uncached count from another call and hide ambiguous input.
+    if (usage) {
+      const callWarning = checkCacheUsage(usage, requireExplicitUncachedInputTokens);
+      warning ??= callWarning;
+    }
     if (!byModel[model]) {
       byModel[model] = { calls: 0, usage: emptyUsage(), cost: null };
     }
@@ -105,7 +153,7 @@ export async function tallyCosts({
   let total: CostBreakdown | null = null;
   for (const [model, row] of Object.entries(byModel)) {
     const pricing = await resolvePricing(model);
-    row.cost = estimateUsdCost({ usage: row.usage, pricing });
+    row.cost = pricing ? calculateUsdCost(row.usage, pricing) : null;
     if (row.cost) {
       if (!total) total = { inputUsd: 0, outputUsd: 0, totalUsd: 0 };
       total.inputUsd += row.cost.inputUsd;
@@ -114,5 +162,5 @@ export async function tallyCosts({
     }
   }
 
-  return { total, byModel };
+  return { total, byModel, ...(warning ? { warnings: [warning] } : {}) };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,3 +40,20 @@ export type CostBreakdown = {
   outputUsd: number;
   totalUsd: number;
 };
+
+/** Recoverable ambiguity in manually constructed cache-bearing usage. */
+export type TokenUsageWarning = {
+  code: "AMBIGUOUS_CACHED_INPUT";
+  message: string;
+};
+
+/** Cost estimate with one warning when cache-bearing input lacks an explicit uncached count. */
+export type CostEstimate = CostBreakdown & {
+  warnings?: TokenUsageWarning[];
+};
+
+/** Shared validation options for estimation and tallying. */
+export type CostEstimationOptions = {
+  /** Reject cache-bearing usage without an explicit uncached count. Defaults to false. */
+  requireExplicitUncachedInputTokens?: boolean;
+};

--- a/tests/tally.test.ts
+++ b/tests/tally.test.ts
@@ -1,6 +1,168 @@
 import { estimateUsdCost, pricingFromUsdPerMillion, tallyCosts } from "../src/index.js";
 import { normalizeTokenUsage } from "../src/usage.js";
 
+describe("explicit uncached input validation", () => {
+  const pricing = pricingFromUsdPerMillion({
+    inputUsdPerMillion: 1,
+    outputUsdPerMillion: 2,
+    cachedInputUsdPerMillion: 0.1,
+  });
+  const direct = { inputTokens: 1000, outputTokens: 50, cachedInputTokens: 400 };
+  const explicit = { ...direct, uncachedInputTokens: 600 };
+  const openai = normalizeTokenUsage({
+    prompt_tokens: 1000,
+    completion_tokens: 50,
+    prompt_tokens_details: { cached_tokens: 400 },
+  });
+  const anthropic = normalizeTokenUsage({
+    input_tokens: 1000,
+    output_tokens: 50,
+    cache_read_input_tokens: 400,
+  });
+  const error = /normalizeTokenUsage\(\).*explicit uncachedInputTokens/;
+
+  it("preserves the ambiguous default estimate with one actionable structured warning", () => {
+    for (let invocation = 0; invocation < 2; invocation++) {
+      const cost = estimateUsdCost({ usage: direct, pricing });
+      expect(cost?.totalUsd).toBeCloseTo(0.00114, 12);
+      expect(cost?.warnings).toEqual([
+        { code: "AMBIGUOUS_CACHED_INPUT", message: expect.stringMatching(error) },
+      ]);
+    }
+    expect(
+      estimateUsdCost({ usage: direct, pricing, requireExplicitUncachedInputTokens: false }),
+    ).toEqual(estimateUsdCost({ usage: direct, pricing }));
+  });
+
+  it("rejects ambiguous direct estimates in strict mode", () => {
+    expect(() =>
+      estimateUsdCost({ usage: direct, pricing, requireExplicitUncachedInputTokens: true }),
+    ).toThrow(TypeError);
+    expect(() =>
+      estimateUsdCost({ usage: direct, pricing, requireExplicitUncachedInputTokens: true }),
+    ).toThrow(error);
+  });
+
+  it.each([false, true])(
+    "prices explicit and provider-normalized input in strict=%s",
+    async (strict) => {
+      for (const [usage, expected] of [
+        [explicit, 0.00074],
+        [openai, 0.00074],
+        [anthropic, 0.00114],
+      ] as const) {
+        const cost = estimateUsdCost({
+          usage,
+          pricing,
+          requireExplicitUncachedInputTokens: strict,
+        });
+        expect(cost?.totalUsd).toBeCloseTo(expected, 12);
+        expect(cost).not.toHaveProperty("warnings");
+        const result = await tallyCosts({
+          calls: [{ model: "example/model", usage }],
+          resolvePricing: () => pricing,
+          requireExplicitUncachedInputTokens: strict,
+        });
+        expect(result.total?.totalUsd).toBeCloseTo(expected, 12);
+        expect(result).not.toHaveProperty("warnings");
+      }
+    },
+  );
+
+  it("warns for direct tallies and rejects them in strict mode", async () => {
+    const calls = [{ model: "example/model", usage: direct }];
+    const result = await tallyCosts({ calls, resolvePricing: () => pricing });
+    expect(result.total?.totalUsd).toBeCloseTo(0.00114, 12);
+    expect(result.warnings).toHaveLength(1);
+    await expect(
+      tallyCosts({
+        calls,
+        resolvePricing: () => pricing,
+        requireExplicitUncachedInputTokens: true,
+      }),
+    ).rejects.toThrow(error);
+  });
+
+  it.each([false, true])(
+    "detects mixed input before aggregation, reversed=%s",
+    async (reversed) => {
+      const calls = [direct, openai].map((usage) => ({ model: "example/model", usage }));
+      if (reversed) calls.reverse();
+      const result = await tallyCosts({ calls, resolvePricing: () => pricing });
+      expect(result.total?.totalUsd).toBeCloseTo(0.00188, 12);
+      expect(result.warnings?.map((warning) => warning.code)).toEqual(["AMBIGUOUS_CACHED_INPUT"]);
+      const resolvePricing = vi.fn(() => pricing);
+      await expect(
+        tallyCosts({
+          calls,
+          resolvePricing,
+          requireExplicitUncachedInputTokens: true,
+        }),
+      ).rejects.toThrow(error);
+      expect(resolvePricing).not.toHaveBeenCalled();
+      const corrected = await tallyCosts({
+        calls: [explicit, openai].map((usage) => ({ model: "example/model", usage })),
+        resolvePricing,
+        requireExplicitUncachedInputTokens: true,
+      });
+      expect(corrected.total?.totalUsd).toBeCloseTo(0.00148, 12);
+      expect(corrected).not.toHaveProperty("warnings");
+    },
+  );
+
+  it("deduplicates warnings across calls and models even without pricing", async () => {
+    const result = await tallyCosts({
+      calls: ["a", "a", "b"].map((model) => ({ model, usage: direct })),
+      resolvePricing: () => null,
+    });
+    expect(result.total).toBeNull();
+    expect(result.warnings).toHaveLength(1);
+    expect(result.byModel.a?.calls).toBe(2);
+  });
+
+  it.each([
+    { cachedInputTokens: 0 },
+    { cacheCreationInputTokens: 0 },
+    { cacheCreationInputTokens: 400 },
+  ])("validates present cache fields %j and accepts explicit zero uncached input", (cache) => {
+    const usage = { inputTokens: 0, outputTokens: 0, ...cache };
+    expect(estimateUsdCost({ usage, pricing })?.warnings).toHaveLength(1);
+    expect(() =>
+      estimateUsdCost({ usage, pricing, requireExplicitUncachedInputTokens: true }),
+    ).toThrow(error);
+    expect(
+      estimateUsdCost({
+        usage: { ...usage, uncachedInputTokens: 0 },
+        pricing,
+        requireExplicitUncachedInputTokens: true,
+      }),
+    ).not.toHaveProperty("warnings");
+  });
+
+  it("keeps missing-data defaults and validates strict input before missing pricing", () => {
+    expect(estimateUsdCost({ usage: direct, pricing: null })).toBeNull();
+    expect(
+      estimateUsdCost({ usage: null, pricing, requireExplicitUncachedInputTokens: true }),
+    ).toBeNull();
+    expect(() =>
+      estimateUsdCost({
+        usage: direct,
+        pricing: null,
+        requireExplicitUncachedInputTokens: true,
+      }),
+    ).toThrow(error);
+    const cost = estimateUsdCost({
+      usage: { inputTokens: 1000, outputTokens: 50 },
+      pricing,
+      requireExplicitUncachedInputTokens: true,
+    });
+    expect(cost?.inputUsd).toBeCloseTo(0.001, 12);
+    expect(cost?.outputUsd).toBeCloseTo(0.0001, 12);
+    expect(cost?.totalUsd).toBeCloseTo(0.0011, 12);
+    expect(cost).not.toHaveProperty("warnings");
+  });
+});
+
 describe("tallyCosts", () => {
   it("computes totals and per-model breakdown", async () => {
     const calls = [


### PR DESCRIPTION
Manually constructed cache-bearing usage can mean inclusive OpenAI input or additive Anthropic input. With 1,000 input tokens and 400 cached tokens, the current fallback estimates $0.00114 where inclusive input should cost $0.00074.

Add `requireExplicitUncachedInputTokens` to `estimateUsdCost` and `tallyCosts`. Strict mode rejects cache-bearing usage without an explicit uncached count and explains how to normalize the original provider payload or provide the count. Tally validation runs on each original call before aggregation and pricing lookup, preventing mixed calls from masking ambiguity.

The default preserves numeric behavior and returns one structured `AMBIGUOUS_CACHED_INPUT` warning per affected result. No console or stderr logging occurs. Unambiguous results retain their existing shape, and numeric `CostBreakdown` values remain unchanged. README documents both provider interpretations, warning semantics, strict validation, and the future default flip whose version and timing remain undecided.

Refs #38. Thanks @devYRPauli for the report and accounting examples. This prepares the compatible mitigation; it does not change the default accounting contract. Changelog preparation is in a separate final notes PR to keep the sweep's branches independent.

Validation: `pnpm check` (40 tests, coverage, formatting, lint, type checks, build, attw, publint), plus an installed-tarball integration run covering strict/default estimates and tallies, warning deduplication, both mixed-call orders, corrected totals, live LiteLLM pricing, and disk-cache reuse. Captured stderr was empty. Independent Codex autoreview covers the change before landing.
