### PR TITLE
docs: prepare cached-input validation release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.1.6 (Unreleased)
 
+**Highlights:** Detect ambiguous cached-token accounting while preserving existing default totals.
+
+- Core API: add opt-in `requireExplicitUncachedInputTokens` validation to estimates and tallies, and return one structured warning per ambiguous result by default without console logging (thanks @devYRPauli)
+- Docs: explain inclusive OpenAI and additive Anthropic cache counts, explicit-count migration, and the planned future strict default whose major/minor version and timing remain undecided
+
 ## 0.1.5 - 2026-09-05
 
 - Tooling: refresh the test and coverage runner, build and package validation tools, Node types, formatter, linter, Vite, PostCSS, pnpm, and transitive dependencies


### PR DESCRIPTION
Prepare the complete `0.1.6 (Unreleased)` notes for #42, led by detecting ambiguous cache accounting while retaining default numeric totals. Credit @devYRPauli and document that the future strict default still awaits a major/minor version and migration decision.

This branch is independent of #42 and changes only CHANGELOG.md. Merge #42 first, then this notes PR. Released sections remain unchanged. Recommend patch 0.1.6 for this bounded compatibility-preserving mitigation; no version bump, tag, or publication is included.

Validation: diff whitespace checks, verification that released notes are unchanged, and clean independent Codex autoreview through P2. The implementation has a passing 40-test full gate and an installed-tarball integration run covering both accounting modes, mixed tallies, warning deduplication, live catalog pricing, and cache reuse; its proof is recorded on #42.
